### PR TITLE
Support Site Specific Cookbooks

### DIFF
--- a/lib/chef_fs/file_system/chef_repository_file_system_entry.rb
+++ b/lib/chef_fs/file_system/chef_repository_file_system_entry.rb
@@ -50,8 +50,16 @@ module ChefFS
       end
 
       def children
-        @children ||= Dir.entries(file_path).select { |entry| entry != '.' && entry != '..' && !ignored?(entry) }.
-                                             map { |entry| ChefRepositoryFileSystemEntry.new(entry, self) }
+        @children ||= begin
+          file_paths = Array(File.basename(file_path) == 'cookbooks' ? Chef::Config.cookbook_path : file_path)
+          childs = []
+          file_paths.each do |file_path|
+            childs += Dir.entries(file_path).
+              select { |entry| entry != '.' && entry != '..' && !ignored?(entry) }.
+              map { |entry| ChefRepositoryFileSystemEntry.new(entry, self, "#{file_path}/#{entry}") }
+          end
+          childs
+        end
       end
 
       attr_reader :chefignore

--- a/lib/chef_fs/knife.rb
+++ b/lib/chef_fs/knife.rb
@@ -25,7 +25,7 @@ module ChefFS
     end
 
     def chef_repo
-      @chef_repo ||= File.expand_path(File.join(Chef::Config.cookbook_path, ".."))
+      @chef_repo ||= File.expand_path(File.join(Array(Chef::Config.cookbook_path).first, ".."))
     end
 
     def format_path(path)


### PR DESCRIPTION
This path would be useful for developers, who puts site-cookbooks in different directory than common cookbooks directory.
refs. [Chef/Cookbooks-SiteSpecificCookbooks](http://wiki.opscode.com/display/chef/Cookbooks#Cookbooks-SiteSpecificCookbooks)
