### PR TITLE
knife cookbook test fails...

### DIFF
--- a/lib/chef/knife/raw_essentials.rb
+++ b/lib/chef/knife/raw_essentials.rb
@@ -4,7 +4,6 @@ class Chef
   class Knife
     remove_const(:Raw) if const_defined?(:Raw) && Raw.name == 'Chef::Knife::Raw' # override Chef's version
     class Raw < Chef::Knife
-      ChefFS = ::ChefFS
       banner "knife raw REQUEST_PATH"
 
       option :method,


### PR DESCRIPTION
When I run:

``` bash
bundle exec knife cookbook test COOKBOOK
```

I get:

``` text
/var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/knife-essentials-0.8.1/lib/chef/knife/raw_essentials.rb:7:in `<class:Raw>': uninitialized constant ChefFS (NameError)
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/knife-essentials-0.8.1/lib/chef/knife/raw_essentials.rb:6:in `<class:Knife>'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/knife-essentials-0.8.1/lib/chef/knife/raw_essentials.rb:4:in `<class:Chef>'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/knife-essentials-0.8.1/lib/chef/knife/raw_essentials.rb:3:in `<top (required)>'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/knife/core/subcommand_loader.rb:37:in `load'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/knife/core/subcommand_loader.rb:37:in `block in load_commands'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/knife/core/subcommand_loader.rb:37:in `each'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/knife/core/subcommand_loader.rb:37:in `load_commands'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/knife.rb:114:in `load_commands'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/knife.rb:162:in `run'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/lib/chef/application/knife.rb:123:in `run'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/gems/chef-10.16.4/bin/knife:25:in `<top (required)>'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/bin/knife:23:in `load'
    from /var/lib/jenkins/workspace/chef-hosted/vendor/bundle/ruby/1.9.1/bin/knife:23:in `<main>'
```
- Ruby 1.9.3
- Chef 10.16.4
- KE 0.8.1
