### PR TITLE
Update the cache when a parent is created

### DIFF
--- a/lib/chef_fs/file_system.rb
+++ b/lib/chef_fs/file_system.rb
@@ -142,6 +142,11 @@ module ChefFS
         found_result = true
         new_dest_parent = get_or_create_parent(dest, options, ui, format_path)
         child_error = copy_entries(src, dest, new_dest_parent, recurse_depth, options, ui, format_path)
+        # Create the internal representation of the fact that the parent will now exist
+        if !new_dest_parent.nil? and !new_dest_parent.parent.nil? and\
+            !new_dest_parent.parent.children.include? new_dest_parent
+          new_dest_parent.parent.children << new_dest_parent
+        end
         error ||= child_error
       end
       if !found_result && pattern.exact_path
@@ -288,7 +293,7 @@ module ChefFS
                 ui.output "Deleted extra entry #{dest_path} (purge is on)" if ui
               end
             else
-              Chef::Log.info("Not deleting extra entry #{dest_path} (purge is off)") if ui
+              ui.output ("Not deleting extra entry #{dest_path} (purge is off)") if ui
             end
           end
 
@@ -406,7 +411,7 @@ module ChefFS
       parent = entry.parent
       if parent && !parent.exists?
         parent_path = format_path.call(parent) if ui
-        parent_parent = get_or_create_parent(entry.parent, options, ui, format_path)
+        parent_parent = get_or_create_parent(parent, options, ui, format_path)
         if options[:dry_run]
           ui.output "Would create #{parent_path}" if ui
         else


### PR DESCRIPTION
If multiple data bag items are specified on the command line to be
uploaded to a data bag that doesn't exist the first will be uploaded
but the next will fail with a 409 CONFLICT.  This is because each item
caches the fact that the parent doesn't exist and tries to create it.

This adds the first created parent to the cache such that subsequent
items do not try to recreate it.

Fix for issue: https://github.com/jkeiser/knife-essentials/issues/107
